### PR TITLE
Add GitHub stats to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Ideas:
 
 ### Primary Technical Skills
 Java, Spring, Node.js, Python
+
+[![Sarah Caulfield's GitHub Stats](https://github-readme-stats.vercel.app/api?username=scaulfield7&show_icons=true&theme=transparent&hide=issues&title_color=ffffff&text_color=848D97&icon_color=848D97&hide_rank=true)](https://github.com/anuraghazra/github-readme-stats)


### PR DESCRIPTION
Add personalised GitHub stats to README with transparent background to suit all themes, and font and icon colours which match the GitHub theme.